### PR TITLE
Feature/url parameters

### DIFF
--- a/Codemine/Extensions/CGPoint+Utilities.swift
+++ b/Codemine/Extensions/CGPoint+Utilities.swift
@@ -16,8 +16,8 @@ public extension CGPoint {
      If the actual point is close to the `point` from the parameter it will return true.
      
      - Parameters:
-     - point: The `CGPoint` that will be checked if it is close to the actual `CGPoint`.
-     - tolerance: Defines what range is tolerated to be close to the other `point`.
+        - point: The `CGPoint` that will be checked if it is close to the actual `CGPoint`.
+        - tolerance: Defines what range is tolerated to be close to the other `point`.
      
      - Returns: `Boolean` - if close to return true, else false.
      */

--- a/Codemine/Extensions/NSURL+Utilities.swift
+++ b/Codemine/Extensions/NSURL+Utilities.swift
@@ -34,12 +34,12 @@ public extension URL {
      Adds height, width and mode paramters to an url. To be used when fetching an image from a CDN, for example.
      Choose the `size` and the `mode` for the image url to define how an image will be provided from the backend.
      
-     - Parameters:
-     - size: Set `size` as `CGSize` to define the size of the image that will be provided.
-     - mode: Select a mode from predefined `ImageUrlMode` to set up a mode and define how an image will be provided.
-     - heightParameterName: the name of the height paramter. Default is 'h'
-     - widthParameterName: the name of the width paramter. Default is 'h'
-     - Returns: `URL` as a `NSURL`.
+     - parameters:
+        - size: Set `size` as `CGSize` to define the size of the image that will be provided.
+        - mode: Select a mode from predefined `ImageUrlMode` to set up a mode and define how an image will be provided.
+        - heightParameterName: the name of the height paramter. Default is 'h'
+        - widthParameterName: the name of the width paramter. Default is 'h'
+     - returns: `URL` as a `NSURL`.
      */
     public func appendingAssetSize(_ size: CGSize, mode: ImageUrlMode = .default, heightParameterName : String = "h", widthParameterName : String = "w") -> URL? {
         guard var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return nil }
@@ -55,10 +55,10 @@ public extension URL {
     }
 
     /**
-        Finds the first value for a URL parameter in a `URL`
-        - Parameters:
+     Finds the first value for a URL parameter in a `URL`
+     - parameters:
         - name: the URL parameter to look for
-        - Returns: the first value found for `name` or nil if no value was found
+     - returns: the first value found for `name` or nil if no value was found
      */
     public func value(forParameter name: String) -> String? {
         guard let urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: true),
@@ -68,5 +68,22 @@ public extension URL {
         let items = queryItems.filter({ $0.name == name })
         return items.first?.value
     }
- 
+    
+    /**
+     Appends queryParameters to a `URL`
+     - parameters:
+        - queryParameters: a `String` : `String` dictionary containing the queryParameters to append
+     - returns: a new `URL` instance with the appended queryParameters or nil if the appending failed
+     */
+    public func append(queryParameters: [String: String]) -> URL? {
+        guard var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
+            return nil
+        }
+        
+        let urlQueryItems = queryParameters.map{
+            return URLQueryItem(name: $0, value: $1)
+        }
+        urlComponents.queryItems = urlQueryItems
+        return urlComponents.url
+    }
 }

--- a/Codemine/Extensions/UIImage+Utilities.swift
+++ b/Codemine/Extensions/UIImage+Utilities.swift
@@ -18,9 +18,9 @@ public extension UIImage {
      parameter `cornerRadius` for setting up the rounded corners.
      
      - Parameters:
-     - color: The background color.
-     - size: The size of the image.
-     - cornerRadius: The corner radius.
+        - color: The background color.
+        - size: The size of the image.
+        - cornerRadius: The corner radius.
      
      - Returns: A 'UIImage' with the specified color, size and corner radius.
      */
@@ -59,8 +59,8 @@ public extension UIImage {
      The `UIImage` that is set with the parameter `icon` will be centered on `image`.
      
      - Parameters:
-	 - icon: The embedded image that will be on top.
-     - image: The background image.
+        - icon: The embedded image that will be on top.
+        - image: The background image.
      - Returns: The combined image as `UIImage`.
      */
     public class func embed(icon: UIImage, inImage image: UIImage ) -> UIImage? {

--- a/Codemine/Extensions/UIView+Utilities.swift
+++ b/Codemine/Extensions/UIView+Utilities.swift
@@ -26,8 +26,8 @@ public extension UIView {
      Rounded corners for a `UIView`.
      
      - Parameters:
-     - corners: Defines which corners should be rounded.
-     - radius: Defines the radius of the round corners as a `CGFloat`.
+        - corners: Defines which corners should be rounded.
+        - radius: Defines the radius of the round corners as a `CGFloat`.
      */
     public func roundViewCorners(_ corners:UIRectCorner, radius: CGFloat) {
         let path = UIBezierPath(roundedRect: self.bounds, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))

--- a/CodemineTests/CodemineTests.swift
+++ b/CodemineTests/CodemineTests.swift
@@ -52,7 +52,7 @@ class CodemineTests: XCTestCase {
     func testRange() {
         let str = "Hello world!"
 		let range = str.range(from: "e", toString: " w")
-        XCTAssertTrue(range?.lowerBound == str.characters.index(str.startIndex, offsetBy: 1) && range?.upperBound == str.characters.index(str.startIndex, offsetBy: 7), "range = \(range)")
+        XCTAssertTrue(range?.lowerBound == str.index(str.startIndex, offsetBy: 1) && range?.upperBound == str.index(str.startIndex, offsetBy: 7), "range = \(range)")
         XCTAssertNil(str.range(from: "a", toString: "e"))
         XCTAssertNil(str.range(from: "e", toString: "b"))
 		

--- a/CodemineTests/URLParameterTests.swift
+++ b/CodemineTests/URLParameterTests.swift
@@ -57,6 +57,37 @@ class URLParameterTests: XCTestCase {
             return
         }
         XCTAssertNil(urlWithNoParameters.value(forParameter: "nothere"))
+        
+    }
+    
+    func testCanReturnValueFromURLWithTwoParametersWithTheSameName() {
+        guard let urlWithTwoParametersWithSameName = URL(string: "https://example.com?param1=value1&param2=value2&param1=value3") else {
+            XCTFail("could not create URL")
+            return
+        }
+        
+        let expectedValue = "value1"
+        guard let actualValue = urlWithTwoParametersWithSameName.value(forParameter: "param1") else {
+            XCTFail("no value found for parameter")
+            return
+        }
+        XCTAssertTrue(expectedValue == actualValue)
+    }
+    
+    func testCanAppendQueryParameters() {
+        guard let url = URL(string: "https://example.com") else {
+            XCTFail("could not create URL")
+            return
+        }
+        
+        guard let queryParamUrl = url.append(queryParameters: ["param1" : "value1", "param2" : "value2"]) else {
+            XCTFail("could not create queryParamUrl")
+            return
+        }
+        
+        XCTAssertNotNil(queryParamUrl.value(forParameter: "param1"))
+        XCTAssertNotNil(queryParamUrl.value(forParameter: "param2"))
+
     }
     
 }

--- a/CodemineTests/URLParameterTests.swift
+++ b/CodemineTests/URLParameterTests.swift
@@ -80,13 +80,21 @@ class URLParameterTests: XCTestCase {
             return
         }
         
-        guard let queryParamUrl = url.append(queryParameters: ["param1" : "value1", "param2" : "value2"]) else {
+        let expectedValue1 = "value1"
+        let expectedValue2 = "value2"
+        
+        guard let queryParamUrl = url.append(queryParameters: ["param1" : expectedValue1, "param2" : expectedValue2]) else {
             XCTFail("could not create queryParamUrl")
             return
         }
         
+        //Are they even there?
         XCTAssertNotNil(queryParamUrl.value(forParameter: "param1"))
         XCTAssertNotNil(queryParamUrl.value(forParameter: "param2"))
+        
+        //They were, but do they match then?
+        XCTAssertTrue(queryParamUrl.value(forParameter: "param1")! == expectedValue1)
+        XCTAssertTrue(queryParamUrl.value(forParameter: "param2")! == expectedValue2)
 
     }
     


### PR DESCRIPTION
adds new append function to URL extension
 
You can now append `queryParameters` to a `URL` object.

also:
- fixes formatting of documentation so parameters show up as expected